### PR TITLE
Update device_file.c

### DIFF
--- a/device_file.c
+++ b/device_file.c
@@ -193,7 +193,7 @@ int register_device(void)
 	gpioIRQs[i] = gpio_to_irq(encoder_pins[i]);
 	gpio_request(encoder_pins[i],"encoder");
 	gpio_direction_input(encoder_pins[i]);
-	gpio_export(encoder_pins[i],false);
+	gpiod_export(encoder_pins[i],false);
 	result = request_irq(gpioIRQs[i],(irq_handler_t) irq_handler,IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING,"encoder_irq",NULL);
    }
  
@@ -204,7 +204,7 @@ int register_device(void)
 	gpioIRQs[i] = gpio_to_irq(encoder_pins[i]);
 	gpio_request(encoder_pins[i],"encoder");
 	gpio_direction_input(encoder_pins[i]);
-	gpio_export(encoder_pins[i],false);
+	gpiod_export(encoder_pins[i],false);
 	result = request_irq(gpioIRQs[i],(irq_handler_t) irq_handler,IRQF_TRIGGER_RISING | IRQF_TRIGGER_FALLING,"encoder_irq",NULL);
    }
 #endif
@@ -221,13 +221,13 @@ void unregister_device(void)
 #if QUADRATURE
    for (i = 0; i < 2*NUM_ENCODERS; i++){
 	free_irq(gpioIRQs[i],NULL);
-	gpio_unexport(encoder_pins[i]);
+	gpiod_unexport(encoder_pins[i]);
 	gpio_free(encoder_pins[i]);
    }
 #else
     for (i = 0; i < NUM_ENCODERS; i++){
         free_irq(gpioIRQs[i],NULL);
-        gpio_unexport(encoder_pins[i]);
+        gpiod_unexport(encoder_pins[i]);
         gpio_free(encoder_pins[i]);
    }
 #endif


### PR DESCRIPTION
When compiling on RasPiOS Bookworm (2024-09-02) the system gave errors on lines 196 and 224 about Implicit Declaration of "gpio_export" and "gpio_unexport". It suggested "gpiod_export" and "gpiod_unexport".  These same functions are used a few lines below also.  I have changed them in both places. 

I don't know what this will do to older Raspbian OS or other systems, but it works for today. 

Note: there are still a couple of warnings about other things, but it compiles at least.